### PR TITLE
Refactor/bookazon validate products

### DIFF
--- a/src/Bookazon.java
+++ b/src/Bookazon.java
@@ -25,10 +25,12 @@ public class Bookazon {
         }
     }
 
-    public void validateProducts() {
+    public java.util.List<String> validateProducts() {
+        java.util.List<String> lines = new java.util.ArrayList<>();
         for (MediaItem product : products) {
-            System.out.println(product.getValidator().toString());
+            lines.add(product.validationReport());
         }
+        return lines;
     }
 
     public boolean validateBooksSilently() {
@@ -152,6 +154,10 @@ public class Bookazon {
         bookazon.users.get(0).viewOrders();
 
         for (String line : bookazon.viewUsers()) {
+            System.out.println(line);
+        }
+
+        for (String line : bookazon.validateProducts()) {
             System.out.println(line);
         }
     }

--- a/src/Bookazon.java
+++ b/src/Bookazon.java
@@ -33,7 +33,7 @@ public class Bookazon {
         return lines;
     }
 
-    public boolean validateBooksSilently() {
+    public boolean validateProductsSilently() {
         for (MediaItem product : products) {
             MediaDetails details = product.getDetails();
             if (!product.getValidator().isValid(details)) {
@@ -136,7 +136,7 @@ public class Bookazon {
 
         bookazon.viewProducts();
 
-        boolean allValid = bookazon.validateBooksSilently();
+        boolean allValid = bookazon.validateProductsSilently();
         assert allValid : "One or more books are invalid";
 
         bookazon.addUser(new CustomerUser("Alice", "normal"));

--- a/src/MediaItem.java
+++ b/src/MediaItem.java
@@ -24,6 +24,13 @@ public abstract class MediaItem {
         return validator.isValid(details);
     }
 
+    public String validationReport() {
+        String title = (details.getTitle() != null)
+            ? details.getTitle().getValue()
+            : "(untitled)";
+        return title + ": " + (isValid() ? "valid" : "invalid");
+    }
+
     @Override
     public String toString() {
         return "Media Type: " + getMediaType() + "\n" + details.toString();


### PR DESCRIPTION
## Summary
This will move validation and printing out of Bookazon and hide validator/details behind simple methods.

## Changes Made
- viewProducts() and validateProducts() now return lists and the printing happens in main
- added isValid() and validationReport() to MediaItem and used them in Bookazon
- renamed validateBooksSilently() to validateProductsSilently() for better accuracy

## Why This Change?
It keeps the responsibilities clear and makes the design easier to extend. Also, it's because Bookazon shouldn't print or reach into different items.

## Checklist
- [x] I created a new branch for my changes
- [x] I committed only relevant changes
- [x] I wrote a clear commit message
- [x] I pushed to GitHub and opened this PR
- [x] I requested a review from a teammate