### PR TITLE
YearPublished SRP fix

### DIFF
--- a/src/YearPublished.java
+++ b/src/YearPublished.java
@@ -1,11 +1,19 @@
 public class YearPublished {
     private final int year;
+    private final int currentYear = 2025;
 
     public YearPublished(int year) {
-        if (year <= 0 && year >= 2026) {
+        if (!validateYear(year)) {
             throw new IllegalArgumentException("Year must be valid");
         }
         this.year = year;
+    }
+
+    private boolean validateYear(int year) {
+        if (year <= 0 || year >= (currentYear + 1)) {
+            return false;
+        }
+        return true;
     }
 
     public int getValue() {


### PR DESCRIPTION
### Summary

This commit fixes the SRP violation in the constructor of the YearPublished class and addresses the magic numbers code smell

 ### Changes made

- Created a separate method of year validation
- Added the field currentYear to the class to make the logic of year validation more clear
- Fixed the YearPublished constructor

### Why this change?

The old implementation violated the SRP by making the constructor of the class both set the field year and check for its validity. Also, the logic of year validation was unclear (the number 2026 might be confusing), so the introduction of current year field and the call of it in the validation method resolves it

### Checklist

- [x] I created a new branch for my changes
- [x] I committed only relevant changes
- [x] I wrote a clear commit message
- [x] I pushed to GitHub and opened this PR
- [x] I requested a review from a teammate