### PR TITLE
Refactor subscription model to use classes

### DIFF
--- a/src/Bookazon.java
+++ b/src/Bookazon.java
@@ -63,8 +63,8 @@ public class Bookazon {
         item.apply(u);
     }
 
-    public void updateRole(User user, String role) {
-        user.updateSubscription(role);
+    public void updateRole(User user, Subscription subscription) {
+        user.updateSubscription(subscription);
     }
 
     public static void main(String[] args) {
@@ -139,8 +139,8 @@ public class Bookazon {
         boolean allValid = bookazon.validateProductsSilently();
         assert allValid : "One or more books are invalid";
 
-        bookazon.addUser(new CustomerUser("Alice", "normal"));
-        bookazon.addUser(new CustomerUser("Bob", "gold"));
+        bookazon.addUser(new CustomerUser("Alice", new Silver()));
+        bookazon.addUser(new CustomerUser("Bob", new Gold()));
 
         bookazon.users.get(0).addToCart(bookazon.products.get(0), 1);
         bookazon.users.get(0).addToCart(bookazon.products.get(1), 2);

--- a/src/CustomerUser.java
+++ b/src/CustomerUser.java
@@ -1,5 +1,5 @@
 public class CustomerUser extends User {
-    public CustomerUser(String name, String subscription) {
+    public CustomerUser(String name, Subscription subscription) {
         super(name, subscription);
     }
 

--- a/src/DefaultPricingPolicy.java
+++ b/src/DefaultPricingPolicy.java
@@ -1,19 +1,13 @@
-import java.util.List;
+public class DefaultPricingPolicy extends PricingPolicy {
 
-public class DefaultPricingPolicy implements PricingPolicy {
-
-    @Override
-    public PricingResult price(List<CartItem> items, Subscription subscription) {
+    public DefaultPricingPolicy(Cart cart, Subscription subscription) {
+        super(cart.getItems(), subscription); 
+    }
+    public double calculateTotal() {
         double subtotal = 0.0;
-        for (CartItem item : items) {
+        for (CartItem item : orderItems) {
             subtotal += item.getTotalPrice();
         }
-
-        double discountRate = 0.0;
-        if (subscription != null) {
-            discountRate = subscription.discount();
-        }
-
-        return new PricingResult(subtotal, discountRate);
+        return subtotal * (1 - subscription.discount());
     }
 }

--- a/src/Gold.java
+++ b/src/Gold.java
@@ -1,0 +1,7 @@
+public class Gold extends Subscription {
+    private final double discount = 0.10;
+    private final String level = "Gold";
+    public String level()    { return level; }
+    public double discount() { return discount; }  
+     
+}

--- a/src/NormalSubscription.java
+++ b/src/NormalSubscription.java
@@ -1,0 +1,6 @@
+public class NormalSubscription extends Subscription {
+    @Override
+    public String level()    { return "Normal"; }
+    @Override
+    public double discount() { return 0.0; }
+}

--- a/src/Order.java
+++ b/src/Order.java
@@ -9,29 +9,21 @@ public class Order {
     private String dateShipped;
     private String userName;
     private String orderStatus;
-
     private PostalAddress shippingAddress;
     private PostalAddress billingAddress;
-
     private final ArrayList<CartItem> orderItems;
-
-    private String subscriptionLevel;
-    private final PricingPolicy pricingPolicy;
+    private Subscription subscription;
+    private final DefaultPricingPolicy pricingPolicy;
     private double orderPrice;
 
-    public Order(Cart cart, String subscription) {
-        this(cart, Subscription.of(subscription), new DefaultPricingPolicy());
+     public Order(Cart cart, Subscription subscription) {
+        this(cart, subscription, new DefaultPricingPolicy(cart, subscription));
     }
 
-    public Order(Cart cart, Subscription subscription) {
-        this(cart, subscription, new DefaultPricingPolicy());
-    }
-
-    public Order(Cart cart, Subscription subscription, PricingPolicy pricingPolicy) {
+    public Order(Cart cart, Subscription subscription, DefaultPricingPolicy pricingPolicy) {
         this.orderItems = new ArrayList<>(cart.getItems());
         this.pricingPolicy = pricingPolicy;
-        setSubscription(subscription);
-        recomputeTotals();
+        this.subscription = subscription;
     }
 
     public void setShippingAddress(PostalAddress address) {
@@ -97,21 +89,16 @@ public class Order {
     public double getOrderPrice() {
         return orderPrice;
     }
-
-    private void setSubscription(Subscription subscription) {
-        Subscription effective = (subscription == null) ? Subscription.of("normal") : subscription;
-        this.subscriptionLevel = effective.level();
+    public Subscription getSubscription() {
+        return subscription;
     }
 
-    private void recomputeTotals() {
-        PricingPolicy.PricingResult r = pricingPolicy.price(orderItems, Subscription.of(subscriptionLevel));
-        this.orderPrice = r.total;
+    public void setSubscription(Subscription subscription) {
+        this.subscription = subscription;
     }
 
-    @Deprecated
-    public double calculatePrice(String subscription) {
-        PricingPolicy.PricingResult r = pricingPolicy.price(orderItems, Subscription.of(subscription));
-        return r.total;
+    public double calculatePrice() {
+        return pricingPolicy.calculateTotal();
     }
 
     public void printOrderDetails() {

--- a/src/OrderService.java
+++ b/src/OrderService.java
@@ -8,7 +8,7 @@ public class OrderService {
         if (user == null) throw new IllegalArgumentException("user cannot be null");
         if (user.getCart() == null) throw new IllegalStateException("user cart cannot be null");
         if (user.getSubscription() == null) throw new IllegalStateException("user subscription cannot be null");
-        Order order = new Order(user.getCart(), user.getSubscription().level());
+        Order order = new Order(user.getCart(), user.getSubscription());
         PostalAddress ship = user.getShippingAddress();
         if (ship != null) {
             order.setShippingAddress(ship);

--- a/src/Platinum.java
+++ b/src/Platinum.java
@@ -1,0 +1,6 @@
+public class Platinum extends Subscription {
+    private final double discount = 0.15;
+    private final String level = "Platinum";
+    public String level()    { return level; }
+    public double discount() { return discount; }  
+}

--- a/src/PricingPolicy.java
+++ b/src/PricingPolicy.java
@@ -1,19 +1,19 @@
-import java.util.List;
+import java.util.ArrayList;
 
-public interface PricingPolicy {
-    PricingResult price(List<CartItem> items, Subscription subscription);
+public abstract class PricingPolicy {
 
-    final class PricingResult {
-        public final double subtotal;
-        public final double discountRate;  
-        public final double discountAmount;
-        public final double total;
+    public ArrayList<CartItem> orderItems;
+    public Subscription subscription;
 
-        public PricingResult(double subtotal, double discountRate) {
-            this.subtotal = subtotal;
-            this.discountRate = discountRate;
-            this.discountAmount = subtotal * discountRate;
-            this.total = subtotal - discountAmount;
+    public PricingPolicy(ArrayList<CartItem> orderItems, Subscription subscription) {
+        this.orderItems = orderItems;
+        this.subscription = subscription;
+    }
+    public double calculateTotal() {
+        double subtotal = 0.0;
+        for (CartItem item : orderItems) {
+            subtotal += item.getTotalPrice();
         }
+        return subtotal * (1 - subscription.discount());
     }
 }

--- a/src/Silver.java
+++ b/src/Silver.java
@@ -1,0 +1,6 @@
+public class Silver extends Subscription {
+    private final double discount = 0.05;
+    private final String level = "Silver";
+    public String level()    { return level; }
+    public double discount() { return discount; }
+}

--- a/src/Subscription.java
+++ b/src/Subscription.java
@@ -1,28 +1,4 @@
-import java.util.Locale;
-import java.util.Map;
-
-public class Subscription {
-    private static final Map<String, Double> DISCOUNTS = Map.of(
-        "normal",   0.00,
-        "silver",   0.05,
-        "gold",     0.15,
-        "platinum", 0.10
-    );
-
-    private final String level;     // normalized lower-case
-    private final double discount;
-
-    private Subscription(String level, double discount) {
-        this.level = level;
-        this.discount = discount;
-    }
-
-    public static Subscription of(String raw) {
-        String key = (raw == null ? "normal" : raw.toLowerCase(Locale.ROOT).trim());
-        if (!DISCOUNTS.containsKey(key)) key = "normal";
-        return new Subscription(key, DISCOUNTS.get(key));
-    }
-
-    public String level()    { return level; }
-    public double discount() { return discount; }
+public abstract class Subscription {
+    public abstract String level();
+    public abstract double discount();
 }

--- a/src/User.java
+++ b/src/User.java
@@ -11,9 +11,9 @@ public abstract class User {
     private PostalAddress shippingAddress;
     private PostalAddress billingAddress;
 
-    protected User(String name, String subscription) {
+    protected User(String name, Subscription subscription) {
         this.name = name;
-        this.subscription = Subscription.of(subscription);
+        this.subscription = subscription;
         this.cart = new Cart();
         this.orders = new ArrayList<>();
     }
@@ -30,8 +30,8 @@ public abstract class User {
         return subscription;
     }
 
-    public void setSubscription(String level) {
-        this.subscription = Subscription.of(level);
+    public void setSubscription(Subscription subscription) {
+        this.subscription = subscription;
     }
 
     public PostalAddress getShippingAddress() {
@@ -98,8 +98,8 @@ public abstract class User {
     protected void onOrderPlaced(Order order) {
     }
 
-    public void updateSubscription(String role) {
-        setSubscription(role);
+    public void updateSubscription(Subscription subscription) {
+        setSubscription(subscription);
     }
 
 }


### PR DESCRIPTION
## Summary
This replaces string-based subscription levels with dedicated `Subscription` subclasses (`Normal`, `Silver`, `Gold`, `Platinum`).  
This simplifies the pricing logic and removes the static mapping previously used in `Subscription`.

## Changes made
- Created dedicated subclasses for each subscription level:  
  - `Normal`  
  - `Silver`  
  - `Gold`  
  - `Platinum`  
- Updated `User`, `Order`, and related classes to use `Subscription` objects instead of raw strings.  
- Removed the static mapping from `Subscription` and moved pricing logic into the respective subclasses.  

## Why this change?
Previously, subscription levels were represented as strings, which caused tight coupling and scattered pricing logic.  
By introducing `Subscription` subclasses, the design is more object-oriented and adheres to the **Open/Closed Principle** (easy to extend with new subscription levels).  
This makes the code more maintainable, readable, and less error-prone.  

## Checklist
- [x] I created a new branch for my changes  
- [x] I committed only relevant changes  
- [x] I wrote a clear commit message  
- [x] I pushed to GitHub and opened this PR  
- [x] I requested a review from a teammate  
